### PR TITLE
Fix range of chars definition in LinkedIn regex

### DIFF
--- a/socials/socials.py
+++ b/socials/socials.py
@@ -19,10 +19,10 @@ GITHUB_URL_REGEXS = [
 
 LINKEDIN_URL_REGEXS = [
     # private
-    'http(s)?://([\w]+\.)?linkedin\.com/in/(A-z0-9_-)+/?',
+    'http(s)?://([\w]+\.)?linkedin\.com/in/[A-z0-9_-]+/?',
     'http(s)?://([\w]+\.)?linkedin\.com/pub/[A-z0-9_-]+(\/[A-z 0-9]+){3}/?',
     # companies
-    'http(s)?://(www\.)?linkedin\.com/company/(A-z0-9_-)+/?',
+    'http(s)?://(www\.)?linkedin\.com/company/[A-z0-9_-]+/?',
 ]
 
 TWITTER_URL_REGEXS = [

--- a/tests/test_socials.py
+++ b/tests/test_socials.py
@@ -46,6 +46,7 @@ def test_extract():
         'http://facebook.com/peterparker',
         'mailto:bill@microsoft.com',
         'steve@microsoft.com',
+        'https://www.linkedin.com/company/google/',
     ]
     extraction = socials.extract(urls)
     matches = extraction.get_matches_per_platform()
@@ -57,3 +58,7 @@ def test_extract():
     assert len(matches['email']) == 2
     assert 'bill@microsoft.com' in matches['email']
     assert 'steve@microsoft.com' in matches['email']
+
+    assert 'linkedin' in matches
+    assert len(matches['linkedin']) == 1
+    assert matches['linkedin'][0] == 'https://www.linkedin.com/company/google/'


### PR DESCRIPTION
What was probably meant to be a range of chars was mistakenly defined with parenthesis `()` instead of brackets `[]`.

This should have been tested.

If you leave this pull request open and I have time I might add some more tests.