### PR TITLE
Make all regexes more strict

### DIFF
--- a/socials/socials.py
+++ b/socials/socials.py
@@ -11,31 +11,31 @@ PLATFORM_INSTAGRAM = 'instagram'
 PLATFORM_EMAIL = 'email'
 
 FACEBOOK_URL_REGEXS = [
-    'http(s)?://(www\.)?(facebook|fb)\.com/[A-z0-9_\-\.]+/?',
+    r'^http(s)?://(www\.)?(facebook|fb)\.com/[A-Za-z0-9_\-\.]+/?$',
 ]
 
 GITHUB_URL_REGEXS = [
-    'http(s)?://(www\.)?github\.com/[A-z0-9_-]+/?',
+    r'^http(s)?://(www\.)?github\.com/[A-Za-z0-9_-]+/?$',
 ]
 
 LINKEDIN_URL_REGEXS = [
     # private
-    'http(s)?://([\w]+\.)?linkedin\.com/in/[A-z0-9_-]+/?',
-    'http(s)?://([\w]+\.)?linkedin\.com/pub/[A-z0-9_-]+(\/[A-z 0-9]+){3}/?',
+    r'^http(s)?://([\w]+\.)?linkedin\.com/in/[A-Za-z0-9_-]+/?$',
+    r'^http(s)?://([\w]+\.)?linkedin\.com/pub/[A-Za-z0-9_-]+(\/[A-z 0-9]+){3}/?$',
     # companies
-    'http(s)?://(www\.)?linkedin\.com/company/[A-z0-9_-]+/?',
+    r'^http(s)?://(www\.)?linkedin\.com/company/[A-Za-z0-9_-]+/?$',
 ]
 
 TWITTER_URL_REGEXS = [
-    'http(s)?://(.*\.)?twitter\.com\/[A-z0-9_]+/?',
+    r'^http(s)?://(.*\.)?twitter\.com\/[A-Za-z0-9_]+/?$',
 ]
 
 INSTAGRAM_URL_REGEXS = [
-    'http(s)?://(www\.)?instagram\.com/[A-Za-z0-9_.]+/?',
-    'http(s)?://(www\.)?instagr\.am/[A-Za-z0-9_.]+/?',
+    r'^http(s)?://(www\.)?instagram\.com/[A-Za-z0-9_.]+/?$',
+    r'^http(s)?://(www\.)?instagr\.am/[A-Za-z0-9_.]+/?$',
 ]
 
-EMAIL_REGEX = '(mailto:)?[\w\.-]+@[\w\.-]+'
+EMAIL_REGEX = r'^(mailto:)?[\w\.-]+@[\w\.-]+$'
 
 
 PATTERNS = {

--- a/tests/test_socials.py
+++ b/tests/test_socials.py
@@ -44,10 +44,15 @@ def test_extract():
         'http://google.de',
         'http://facebook.com',
         'http://facebook.com/peterparker',
+        'http://facebook.com/peter[parker',  # Invalid character
         'mailto:bill@microsoft.com',
         'steve@microsoft.com',
         'https://www.linkedin.com/company/google/',
+        'https://www.linkedin.com/comp^any/google/',  # Invalid character
+        'http://www.twitter.com/Some_Company/',
+        'http://www.twitter.com/Some_\\Company',  # Invalid character
         'https://www.instagram.com/instagram/',
+        'https://www.instagram.com/instag-ram/',  # Invalid character
         'http://instagr.am/instagram',
     ]
     extraction = socials.extract(urls)
@@ -64,6 +69,10 @@ def test_extract():
     assert 'linkedin' in matches
     assert len(matches['linkedin']) == 1
     assert matches['linkedin'][0] == 'https://www.linkedin.com/company/google/'
+
+    assert 'twitter' in matches
+    assert len(matches['twitter']) == 1
+    assert matches['twitter'][0] == 'http://www.twitter.com/Some_Company/'
 
     assert 'instagram' in matches
     assert len(matches['instagram']) == 2


### PR DESCRIPTION
I noticed that some bad strings were being identified as valid matches, for all the platforms. For example, `http://facebook.com/peterparker![]^~` was being treated as valid, as was `http://facebook.com/peter~parker`.  Additionally, the character range `A-z` actually matches some bad characters between Z and a on the ASCII table, so I made those more explicit. Lastly, the tests were throwing some warnings about invalid escape characters (`\.` and `\w`) due to the pattern strings not using the raw prefix, so I added it to all of them.